### PR TITLE
Require ellmer >= 0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Imports:
     cli,
     coro,
     dotenv,
-    ellmer,
+    ellmer (>= 0.3.0),
     shiny,
     shinychat,
     shinyrealtime (>= 0.1.0.9000),


### PR DESCRIPTION
The `ellmer::tool()` specification changed in ellmer 0.3.0, so `ggbot()` doesn't work with earlier ellmer versions